### PR TITLE
Added /speedlinks shortlink (and small related tip)

### DIFF
--- a/hyphacoop/shortlinks/shortlinks.csv
+++ b/hyphacoop/shortlinks/shortlinks.csv
@@ -138,3 +138,4 @@ starling-drive-eng,https://drive.google.com/drive/folders/1x2E05KdLJUnrj3Mg0KxjQ
 starling-drive-sjp,https://drive.google.com/drive/folders/1txPLM3MpQSYN0FkpWP2GBE1sdJCKht0b
 starling-sync-lab2,https://www.dropbox.com/home/sync-lab2/sftp
 starling-mural,https://app.mural.co/t/starlinglab7814/all-murals-grid
+speedlinks,


### PR DESCRIPTION
@benhylau saw you added starling shortlinks in 00fa06b06823f2c6da4793719d95e398df3a4da7, and this reminded me that there was no http://link.hypha.coop/speedlinks shortlink in this repo yet, pointing to https://handbook.hypha.coop/guides.html#accessing-shortlinks

(I've started adding this "speedlinks" shortlink to other projects as a default, to make the life-hack more obvious)

---

Related comment to @benhylau: I wanted to point out that you can set up sub-shortlinks helpers for any sub-projects, like `starling-`. It's small, but helps your browser feel very command-line-y. So `st<tab>drive-eng` takes you to asana, instead of `h<tab>starling-drive-eng` or fulling typing out `http://link.hypha.coop/starling-drive-eng` :)

Example docs for a sub-project (not that you need sub-documentation for Hypha, but helpful to see clearly how it's done):
http://link.g0v.network/walter-report-speedlinks

So if you're working with starling a lot @benhylau, maybe it's useful to your hopping around 🙂 